### PR TITLE
Fix events with arrays.

### DIFF
--- a/src/components/Event.js
+++ b/src/components/Event.js
@@ -1,6 +1,7 @@
 import { observer } from 'mobx-react';
 import omit from 'lodash/omit';
 import React from 'react';
+import { toJS } from 'mobx';
 import yaml from 'js-yaml';
 import './Event.css';
 
@@ -9,7 +10,7 @@ const Event = function ({ event }) {
   const compact = [ ...full, 'id', 'metadata' ];
 
   /* eslint-disable no-extra-parens */
-  const eventDetails = yaml.safeDump(omit(event, compact));
+  const eventDetails = yaml.safeDump(omit(toJS(event), compact));
 
   return (
     <div className='wk-event'>


### PR DESCRIPTION
There is an error in the current version of the `wolkenkit-console`.

If you receive an event that contains an array, the array gets displayed as empty object. This is due to the fact that it is an `mobx.ObservableArray` under the hood. Hence we need to call `mobx.toJS` before transforming the event to YAML.

This PR changes this behavior, so that events are displayed correctly.