### PR TITLE
Improve editor UI.

### DIFF
--- a/src/components/Editor.css
+++ b/src/components/Editor.css
@@ -26,3 +26,8 @@
   font-family: 'Ubuntu Mono', monospace !important;
   font-size: 14px;
 }
+
+.cm-s-neo .CodeMirror-cursor {
+  border-left: 1px solid #819090 !important;
+  width: 0 !important;
+}

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -6,6 +6,7 @@ import 'codemirror/mode/javascript/javascript';
 import 'codemirror/addon/hint/show-hint';
 import 'codemirror/addon/edit/matchbrackets';
 import 'codemirror/addon/edit/closebrackets';
+import 'codemirror/addon/selection/active-line';
 import './Editor.css';
 import '../../node_modules/codemirror/lib/codemirror.css';
 import '../../node_modules/codemirror/addon/hint/show-hint.css';
@@ -71,18 +72,21 @@ class Editor extends Component {
 
     this.editor = new CodeMirror(this.container, {
       autoCloseBrackets: true,
-      value: this.props.value,
-      lineNumbers: true,
-      matchBrackets: true,
-      mode: 'javascript',
-      tabSize: 2,
-      theme: 'neo',
+      autofocus: true,
       extraKeys: {
         'Ctrl-Enter' () {
           onExecute();
         },
         'Ctrl-Space': 'autocomplete'
-      }
+      },
+      lineNumbers: true,
+      matchBrackets: true,
+      mode: 'javascript',
+      showCursorWhenSelecting: true,
+      styleActiveLine: true,
+      tabSize: 2,
+      theme: 'neo',
+      value: this.props.value
     });
 
     this.editor.on('change', this.handleEditorChanged);


### PR DESCRIPTION
I have slightly updated the UI of the editor of `wolkenkit-console`:

- It now automatically focuses itself when the application loads, so you can immediately start typing, and don't have to click first.
- It highlights the active line, so that it becomes easier to navigate in larger code blocks.
- It now displays the cursor as a line instead of a block, so that it looks more like what people are used to from Atom & co.